### PR TITLE
Fix crash when dragging on virtual keyboard beyond left edge

### DIFF
--- a/src/drumkv1_ui.cpp
+++ b/src/drumkv1_ui.cpp
@@ -284,6 +284,9 @@ QString drumkv1_ui::noteName ( int note )
 		QT_TR_NOOP("B")
 	};
 
+   if (note < 0)
+		note = 0;
+
 	return QString("%1 %2").arg(s_notes[note % 12]).arg((note / 12) - 1);
 }
 


### PR DESCRIPTION
When clicking&dragging with the mouse on the virtual keyboard,
a crash will happen if you move the mouse quickly to the left beyond
the keyboard (this creates negative values for "note"), causing a
lookup error in drumkv1_ui::noteName().

By the way, this my first GitHub pull request ever, so let me know if I screwed up somehow :-).
